### PR TITLE
Update hash function to not provide an error callback and throw excep…

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -24,6 +24,8 @@ var bsfy = require( 'browserify' );
  *                                        can degrade performance
  * @param {Array}  [opts.include=[]]      - Additional files to include in the
  *                                        dep tree
+ *
+ * @returns {Object} Browserify bundle (readable stream).
  */
 module.exports = function ( entryFile, cb, opts ) {
 
@@ -64,13 +66,14 @@ module.exports = function ( entryFile, cb, opts ) {
             )
         );
 
-    // Return a hash of the sorted, concatinated dependency hashes. Throw any
-    // encountered errors.
+    /**
+     * Return a hash of the sorted, concatenated dependency hashes.
+     * Returns a Node.js Readable stream (EventEmitter), so tie into its
+     * error callback for error handling downstream.
+     */
     return opts.bsfy.bundle(
         _.curry( module.exports._generateHash )( opts, cb, srcHashReg )
-    ).on( 'error', function ( err ) {
-        throw new Error( err );
-    } );
+    );
 };
 
 // Register a dependency and its source hash from the 'deps' phase of the
@@ -105,4 +108,4 @@ module.exports._generateHash = function ( opts, cb, srcHashReg, err, bundle ) {
         md5( _.values( srcHashReg ).sort().join( '' ) ),
         srcHashReg
     );
-} ;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-hash",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Detect changes to a Browserify bundle's source files",
   "directories": {
     "test": "test",
@@ -12,7 +12,7 @@
   "author": "Rob McGuire-Dale <rmcguir@rei.com>",
   "license": "MIT",
   "dependencies": {
-    "browserify": "^11.0.1",
+    "browserify": "^13.0.1",
     "fs-extra": "^0.24.0",
     "lodash": "^3.10.1",
     "md5": "^2.0.0",


### PR DESCRIPTION
…tion. This prevents downstream code from handling the error since you cannot catch the exception being thrown in a stream error callback. Additionally, you cannot provide your own error callback since it's being handled at this lower level. Simply return the stream and let downstream code handle the errors. Update browserify while we're in here.